### PR TITLE
knack 0.11.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,46 @@
 {% set name = "knack" %}
-{% set version = "0.6.3" %}
+{% set version = "0.11.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b1ac92669641b902e1aef97138666a21b8852f65d83cbde03eb9ddebf82ce121
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: eb6568001e9110b1b320941431c51033d104cc98cda2254a5c2b09ba569fd494
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python
     - pip
+    - python
+    - wheel
+    - setuptools
   run:
     - python
     - argcomplete
-    - colorama
     - jmespath
+    - packaging
     - pygments
     - pyyaml
-    - six
     - tabulate
 
 test:
+  source_files:
+    - tests
   imports:
     - knack
     - knack.testsdk
+  commands:
+    - pip check
+    - pytest -v tests
   requires:
+    - pip
     - mock
-    - vcrpy
+    - pytest
 
 about:
   home: https://github.com/microsoft/knack
@@ -42,7 +48,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: A Command-Line Interface framework
-
+  description: A Command-Line Interface framework
   doc_url: https://github.com/Microsoft/knack/tree/master/docs
   dev_url: https://github.com/microsoft/knack
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ test:
     - pip
     - mock
     - pytest
+    - vcrpy
 
 about:
   home: https://github.com/microsoft/knack


### PR DESCRIPTION
knack 0.11.0 

**Destination channel:** Defaults

### Links

- [PKG-13831]
- dev_url:        https://github.com/microsoft/knack/tree/v0.11.0
- conda_forge:    https://github.com/conda-forge/knack-feedstock
- pypi:           https://pypi.org/project/knack/0.11.0
- pypi inspector: https://inspector.pypi.io/project/knack/0.11.0

### Explanation of changes:

- new version number


[PKG-13831]: https://anaconda.atlassian.net/browse/PKG-13831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ